### PR TITLE
Changed tabs to spaces

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -113,7 +113,7 @@ const struct NamedCommand conf_commands[] = {
   {"ATMOS_FREQUENCY",     12},
   {"RESIZE_MOVIES",       13},
   {"MUSIC_TRACKS",        14},
-  {"CUSTOM_ATMOS",	      15},
+  {"CUSTOM_ATMOS",        15},
   {NULL,                   0},
   };
 
@@ -752,7 +752,7 @@ short load_configuration(void)
                 COMMAND_TEXT(cmd_num),config_textname);
           }
           break;
-	  case 15: // Custom atmos
+      case 15: // Custom atmos
           i = recognize_conf_parameter(buf,&pos,len,logicval_type);
           if (i <= 0)
           {
@@ -762,8 +762,8 @@ short load_configuration(void)
           }
           if (i == 1)
               CustomAtmos = true;
-		  else
-			  CustomAtmos = false;
+          else
+              CustomAtmos = false;
           break;
       case 0: // comment
           break;

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -326,14 +326,14 @@ void update_player_sounds(void)
                     // No atmos sounds the first 3 minutes
                     if (game.play_gameturn > 3600)
                     {
-						if (CustomAtmos == true)
-						{
-						play_atmos_sound(1035 + UNSYNC_RANDOM(samples_in_bank - 1035));	
-						}
-						else
-						{
+                        if (CustomAtmos == true)
+                        {
+                        play_atmos_sound(1035 + UNSYNC_RANDOM(samples_in_bank - 1035));    
+                        }
+                        else
+                        {
                         play_atmos_sound(1014 + UNSYNC_RANDOM(21));
-						}
+                        }
                     }
                 } else
                 {


### PR DESCRIPTION
The rest of the code uses 'spaces' instead of tabs, like this. To keep it consistent, it's nice to keep using this.