### PR TITLE
shift can now find square and rectangular rooms 

### DIFF
--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -260,7 +260,7 @@ int can_thing_be_queried(struct Thing *thing, long a2);
 struct Thing *get_queryable_object_near(MapCoord pos_x, MapCoord pos_y, long plyr_idx);
 TbBool tag_cursor_blocks_sell_area(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long a4, TbBool Subtile, char radius, TbBool even);
 long packet_place_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel dormodel, unsigned char a5);
-TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long a4, long radius, TbBool even);
+TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long a4, int width, int height);
 TbBool tag_cursor_blocks_place_door(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool all_dungeons_destroyed(const struct PlayerInfo *win_player);
 void reset_gui_based_on_player_mode(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4003,7 +4003,7 @@ TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
         allowed = true;
     }
     int roomslabs = width * height;
-    int canbuild = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height);
+    int canbuild = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height, 0);
     int color = 0;
     if (canbuild > 0)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3967,7 +3967,7 @@ TbBool tag_cursor_blocks_place_door(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     return allowed;
 }
 
-TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long a4, long radius, TbBool even)
+TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long a4, int width, int height)
 {
     SYNCDBG(7,"Starting");
     //return _DK_tag_cursor_blocks_place_room(plyr_idx, a2, a3, a4);
@@ -3982,7 +3982,6 @@ TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     struct PlayerInfo *player;
     player = get_player(plyr_idx);
     int par1;
-    int dist = radius * 3;
     if (!subtile_revealed(stl_x, stl_y, plyr_idx) ||
        ((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0))
     {
@@ -4003,8 +4002,8 @@ TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
         SYNCDBG(7,"Cannot build %s on slab (%d,%d)",slab_code_name(slb->kind),room_code_name(player->chosen_room_kind),(int)slb_x,(int)slb_y);
         allowed = true;
     }
-    int roomslabs = (1 + radius + radius + even) * (1 + radius + radius + even);
-    int canbuild = can_build_room_of_radius(plyr_idx, player->chosen_room_kind, slb_x, slb_y, radius, even);
+    int roomslabs = width * height;
+    int canbuild = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height);
     int color = 0;
     if (canbuild > 0)
     {
@@ -4024,13 +4023,13 @@ TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2))
     {
         map_volume_box.visible = 1;
-        map_volume_box.beg_x = subtile_coord(slab_subtile(slb_x, 0) - dist, 0);
-        map_volume_box.beg_y = subtile_coord(slab_subtile(slb_y, 0) - dist, 0);
+        map_volume_box.beg_x = subtile_coord(slab_subtile(slb_x, 0) - (calc_distance_from_centre(width, 0) * 3), 0);
+        map_volume_box.beg_y = subtile_coord(slab_subtile(slb_y, 0) - (calc_distance_from_centre(height, 0) * 3), 0);
         map_volume_box.field_13 = par1;
-        map_volume_box.field_17 = 1+ (2 * radius) + even;
-        map_volume_box.end_x = subtile_coord(slab_subtile(slb_x, 3*a4) + (dist + (((char)even)*3)), 0);
+        map_volume_box.field_17 = max(width, height);
+        map_volume_box.end_x = subtile_coord(slab_subtile(slb_x, 3*a4) + (calc_distance_from_centre(width, (width % 2 == 0)) * 3), 0);
+        map_volume_box.end_y = subtile_coord(slab_subtile(slb_y, 3*a4) + (calc_distance_from_centre(height,(height % 2 == 0)) * 3), 0);
         map_volume_box.color = color;
-        map_volume_box.end_y = subtile_coord(slab_subtile(slb_y, 3*a4) + (dist + (((char)even)*3)), 0);
     }
     return allowed;
 }

--- a/src/packets.c
+++ b/src/packets.c
@@ -612,7 +612,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     MapSlabCoord slb_y = subtile_slab(stl_y);
     int width = 1, height = 1;
     int paintMode = 0;
-    if ((pckt->control_flags & PCtr_LBtnHeld) != PCtr_LBtnHeld)
+    if ((is_key_pressed(KC_LCONTROL, KMod_DONTCARE)) && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld))
     {
         paintMode = 4;
     }
@@ -660,22 +660,16 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     {
         width = height = 9;
     }
-    else if (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)) // Find biggest possible room (strict)
+    else if (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)) // Find biggest possible room
     {
         struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
         struct Dungeon* dungeon = get_players_dungeon(player);
-        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 1 | paintMode);
-    }
-    else if (is_key_pressed(KC_LCONTROL, KMod_DONTCARE)) // Find biggest possible room (loose)
-    {
-        struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
-        struct Dungeon* dungeon = get_players_dungeon(player);
-        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 2 | paintMode);
+        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 2 | paintMode | 8);
     }
     player->boxsize = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height, 0); //number of slabs to build, corrected for blocked tiles
     long i = tag_cursor_blocks_place_room(player->id_number, (slb_x * 3), (slb_y * 3), player->field_4A4, width, height);
     
-    if ((pckt->control_flags & PCtr_LBtnHeld) != PCtr_LBtnHeld)
+    if (paintMode == 0)
     {
         if ((pckt->control_flags & PCtr_LBtnClick) == 0)
         {
@@ -687,7 +681,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
             return false;
         }
     }
-    else
+    else if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld)
     {
         if (player->boxsize == 0)
         {

--- a/src/packets.c
+++ b/src/packets.c
@@ -655,13 +655,19 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     {
         width = height = 9;
     }
-    else if (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)) // Find biggest possible room
+    else if (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)) // Find biggest possible room (strict)
     {
         struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
         struct Dungeon* dungeon = get_players_dungeon(player);
-        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned);
+        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 1);
     }
-    player->boxsize = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height); //number of slabs to build, corrected for blocked tiles
+    else if (is_key_pressed(KC_LCONTROL, KMod_DONTCARE)) // Find biggest possible room (loose)
+    {
+        struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
+        struct Dungeon* dungeon = get_players_dungeon(player);
+        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 2);
+    }
+    player->boxsize = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height, 0); //number of slabs to build, corrected for blocked tiles
     long i = tag_cursor_blocks_place_room(player->id_number, (slb_x * 3), (slb_y * 3), player->field_4A4, width, height);
     if ((pckt->control_flags & PCtr_LBtnClick) == 0)
     {

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -310,7 +310,7 @@ int calc_distance_from_centre(int totalDistance, TbBool offset)
 }
 
 int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
-    MapSlabCoord slb_x, MapSlabCoord slb_y, int width, int height)
+    MapSlabCoord slb_x, MapSlabCoord slb_y, int width, int height, int mode)
 {
     MapCoord buildx;
     MapCoord buildy;
@@ -319,9 +319,28 @@ int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
     {
         for (buildx = slb_x - calc_distance_from_centre(width,0); buildx <= slb_x + calc_distance_from_centre(width,(width % 2 == 0)); buildx++)
         {
-            if (can_build_room_at_slab(plyr_idx, rkind, buildx, buildy))
+            struct SlabMap* slb = get_slabmap_block(buildx, buildy);
+            switch (mode)
             {
-                count++;
+                case 2: // "loose blocking"
+                    if ( slb->kind == SlbT_ROCK || !slab_is_wall(buildx, buildy) )
+                    {
+                        count++;
+                    }
+                    break;
+                case 1: // "strict blocking"
+                    if ( !slab_is_door(buildx, buildy) && !slab_is_liquid(buildx, buildy) && !slab_is_wall(buildx, buildy) )
+                    {
+                        count++;
+                    }
+                    break;
+                default: // "all blocking"
+                    if ( can_build_room_at_slab(plyr_idx, rkind, buildx, buildy) )
+                    {
+                        count++;
+                    }
+                    break;
+                
             }
         }
     }
@@ -329,7 +348,7 @@ int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
 }
 
 int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
-    MapSlabCoord *slb_x, MapSlabCoord *slb_y, int *width, int *height, short roomCost, int totalMoney)
+    MapSlabCoord *slb_x, MapSlabCoord *slb_y, int *width, int *height, short roomCost, int totalMoney, int mode)
 {
     int maxRoomRadius = 5; // 9x9 Room
     int max_width = ((maxRoomRadius * 2) - 1);
@@ -351,6 +370,11 @@ int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
                 }
                 for (int h = max_width; h > 0; h--)
                 {
+                    // reject 1x1 and 1x2 rooms
+                    if (max(w,h) == 1 || (max(w,h) == 2 && min(w,h) == 1)) 
+                    {
+                        continue;
+                    }
                     // get the extents of the current room
                     int RectX1 = c - ((w - 1 - (w % 2 == 0)) / 2);
                     int RectX2 = c + ((w     - (w % 2 != 0)) / 2);
@@ -368,7 +392,8 @@ int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
                         continue;
                     }
                     slabs = w * h;
-                    if ((can_build_room_of_dimensions(plyr_idx, rkind, c, r, w, h) == slabs) && (( slabs * roomCost) <= totalMoney))
+                    int leniency = (mode == 2) ? 0 : 0; // mode=2 :- "loose blocking" (setting to 1 would allow e.g. 1 dirt block in the room)
+                    if ( ((can_build_room_of_dimensions(plyr_idx, rkind, c, r, w, h, mode)) >= slabs - leniency) && ((slabs * roomCost) <= totalMoney) )
                     {
                         if (slabs > biggestRoom) 
                         {

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -320,27 +320,28 @@ int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
         for (buildx = slb_x - calc_distance_from_centre(width,0); buildx <= slb_x + calc_distance_from_centre(width,(width % 2 == 0)); buildx++)
         {
             struct SlabMap* slb = get_slabmap_block(buildx, buildy);
-                if ((mode & 2) == 2) // "loose blocking"
+            struct SlabAttr* slbattr = get_slab_attrs(slb);
+            if ((mode & 2) == 2) // "loose blocking"
+            {
+                if ( !slab_is_wall(buildx, buildy) ) //!((slbattr->block_flags & SlbAtFlg_Blocking) == SlbAtFlg_Blocking) ) // && !slab_is_wall(buildx, buildy)) // || slb->kind == SlbT_ROCK)
                 {
-                    if ( slb->kind == SlbT_ROCK || !slab_is_wall(buildx, buildy) )
-                    {
-                        count++;
-                    }
+                    count++;
                 }
-                else if ((mode & 1) == 1) // "strict blocking"
+            }
+            else if ((mode & 1) == 1) // "strict blocking"
+            {
+                if ( !slab_is_wall(buildx, buildy) && !slab_is_liquid(buildx, buildy) ) //!slab_is_door(buildx, buildy) && !slab_is_wall(buildx, buildy) )
                 {
-                    if ( !slab_is_door(buildx, buildy) && !slab_is_liquid(buildx, buildy) && !slab_is_wall(buildx, buildy) )
-                    {
-                        count++;
-                    }
+                    count++;
                 }
-                else // "all blocking"
+            }
+            else // "all blocking"
+            {
+                if ( can_build_room_at_slab(plyr_idx, rkind, buildx, buildy) )
                 {
-                    if ( can_build_room_at_slab(plyr_idx, rkind, buildx, buildy) )
-                    {
-                        count++;
-                    }
+                    count++;
                 }
+            }
         }
     }
     return count;

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -320,28 +320,27 @@ int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
         for (buildx = slb_x - calc_distance_from_centre(width,0); buildx <= slb_x + calc_distance_from_centre(width,(width % 2 == 0)); buildx++)
         {
             struct SlabMap* slb = get_slabmap_block(buildx, buildy);
-            switch (mode)
-            {
-                case 2: // "loose blocking"
+                if ((mode & 2) == 2) // "loose blocking"
+                {
                     if ( slb->kind == SlbT_ROCK || !slab_is_wall(buildx, buildy) )
                     {
                         count++;
                     }
-                    break;
-                case 1: // "strict blocking"
+                }
+                else if ((mode & 1) == 1) // "strict blocking"
+                {
                     if ( !slab_is_door(buildx, buildy) && !slab_is_liquid(buildx, buildy) && !slab_is_wall(buildx, buildy) )
                     {
                         count++;
                     }
-                    break;
-                default: // "all blocking"
+                }
+                else // "all blocking"
+                {
                     if ( can_build_room_at_slab(plyr_idx, rkind, buildx, buildy) )
                     {
                         count++;
                     }
-                    break;
-                
-            }
+                }
         }
     }
     return count;
@@ -370,10 +369,13 @@ int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
                 }
                 for (int h = max_width; h > 0; h--)
                 {
-                    // reject 1x1 and 1x2 rooms
-                    if (max(w,h) == 1 || (max(w,h) == 2 && min(w,h) == 1)) 
+                    if ((mode & 4) >= 0) // not in painting mode (check disabled: (mode & 4) == 4 to enable)
                     {
-                        continue;
+                        // reject 1x1 and 1x2 rooms
+                        if (max(w,h) == 1 || (max(w,h) == 2 && min(w,h) == 1)) 
+                        {
+                            continue;
+                        }
                     }
                     // get the extents of the current room
                     int RectX1 = c - ((w - 1 - (w % 2 == 0)) / 2);
@@ -392,7 +394,7 @@ int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
                         continue;
                     }
                     slabs = w * h;
-                    int leniency = (mode == 2) ? 0 : 0; // mode=2 :- "loose blocking" (setting to 1 would allow e.g. 1 dirt block in the room)
+                    int leniency = ((mode & 2) == 2) ? 0 : 0; // mode=2 :- "loose blocking" (setting to 1 would allow e.g. 1 dirt block in the room)
                     if ( ((can_build_room_of_dimensions(plyr_idx, rkind, c, r, w, h, mode)) >= slabs - leniency) && ((slabs * roomCost) <= totalMoney) )
                     {
                         if (slabs > biggestRoom) 

--- a/src/slab_data.h
+++ b/src/slab_data.h
@@ -144,10 +144,10 @@ int can_build_room_of_radius(PlayerNumber plyr_idx, RoomKind rkind,
 int calc_distance_from_centre(int totalDistance, TbBool offset);
 
 int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
-    MapSlabCoord slb_x, MapSlabCoord slb_y, int width, int height);
+    MapSlabCoord slb_x, MapSlabCoord slb_y, int width, int height, int mode);
 
 int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
-    MapSlabCoord *slb_x, MapSlabCoord *slb_y, int *width, int *height, short slabCost, int totalMoney);
+    MapSlabCoord *slb_x, MapSlabCoord *slb_y, int *width, int *height, short slabCost, int totalMoney, int mode);
 
 void clear_slabs(void);
 void reveal_whole_map(struct PlayerInfo *player);

--- a/src/slab_data.h
+++ b/src/slab_data.h
@@ -137,10 +137,18 @@ TbBool slab_is_wall(MapSlabCoord slb_x, MapSlabCoord slb_y);
 
 TbBool can_build_room_at_slab(PlayerNumber plyr_idx, RoomKind rkind,
     MapSlabCoord slb_x, MapSlabCoord slb_y);
-    
+
 int can_build_room_of_radius(PlayerNumber plyr_idx, RoomKind rkind,
     MapSlabCoord slb_x, MapSlabCoord slb_y, int radius, TbBool even);
-    
+
+int calc_distance_from_centre(int totalDistance, TbBool offset);
+
+int can_build_room_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
+    MapSlabCoord slb_x, MapSlabCoord slb_y, int width, int height);
+
+int find_biggest_room_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
+    MapSlabCoord *slb_x, MapSlabCoord *slb_y, int *width, int *height, short slabCost, int totalMoney);
+
 void clear_slabs(void);
 void reveal_whole_map(struct PlayerInfo *player);
 void update_blocks_in_area(MapSubtlCoord sx, MapSubtlCoord sy, MapSubtlCoord ex, MapSubtlCoord ey);


### PR DESCRIPTION
Holding shift will now find the largest square/rectangular room that is underneath the cursor. (only "perfect" rooms are found at the moment)

New functions added.

tag_cursor_blocks_place_room() uses width and height instead now.

Placing rooms only, Selling has not been changed yet.

Some of the mathematics might be inefficiently expressed, but it functions correctly.